### PR TITLE
A few minor fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <version>1.15</version>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.goyanov</groupId>
     <artifactId>GraveEntitySpawn</artifactId>
-    <version>1.15</version>
+    <version>1.16.1-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/src/main/java/ges/events/CreatureSpawn.java
+++ b/src/main/java/ges/events/CreatureSpawn.java
@@ -4,6 +4,7 @@ import ges.main.GraveEntitySpawn;
 import ges.utils.PluginSettings;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.bukkit.Location;
@@ -74,6 +75,14 @@ public class CreatureSpawn implements Listener
         }
     }
 
+    private Entity getPrimaryPassenger(LivingEntity ent) {
+        List<Entity> entPassengers = ent.getPassengers();
+        if (entPassengers.isEmpty()) {
+            return null;
+        }
+        return entPassengers.get(0);
+    }
+
     private void smoothEntitySpawnFromGrave(final LivingEntity ent)
     {
         if (this.passengers.contains(ent))
@@ -86,7 +95,7 @@ public class CreatureSpawn implements Listener
         final Location particleLocation = ent.getLocation();
         final Location entLoc = particleLocation.clone();
         fixChunkBoundary(ent, entLoc);
-        final Entity passenger = ent.getPassenger();
+        final Entity passenger = getPrimaryPassenger(ent);
         if (passenger != null)
             this.passengers.add(passenger);
         if (!entLoc.clone().add(0.0D, -1.0D, 0.0D).getBlock().getType().isSolid() || entLoc.getBlock().getType().toString().contains("WATER"))
@@ -125,7 +134,7 @@ public class CreatureSpawn implements Listener
                     entLoc.add(0.0D, step, 0.0D);
                 } else
                 {
-                    if (passenger != null && !passenger.equals(ent.getPassenger()))
+                    if (passenger != null && !passenger.equals(getPrimaryPassenger(ent)))
                         ent.addPassenger(passenger);
                     PluginSettings.getSpawningEntities().remove(ent);
                     if (passenger != null)
@@ -167,7 +176,7 @@ public class CreatureSpawn implements Listener
                 smoothEntitySpawnFromGrave(spawnedEntity);
             } else
             {
-                Entity passenger = spawnedEntity.getPassenger();
+                Entity passenger = getPrimaryPassenger(spawnedEntity);
                 if (passenger != null && isApplicable(passenger.getType()))
                     this.noSpawnPassengers.add(passenger);
             }
@@ -178,7 +187,7 @@ public class CreatureSpawn implements Listener
     {
         if (!PluginSettings.getUseJockeyRider())
             return entity.getType();
-        Entity passenger = entity.getPassenger();
+        Entity passenger = getPrimaryPassenger(entity);
         if (passenger == null)
             return entity.getType();
         return passenger.getType();

--- a/src/main/java/ges/hooks/SimpleProtocolLibHook.java
+++ b/src/main/java/ges/hooks/SimpleProtocolLibHook.java
@@ -29,7 +29,7 @@ public class SimpleProtocolLibHook extends PacketAdapter implements ProtocolLibH
 
     public SimpleProtocolLibHook(JavaPlugin plugin)
     {
-        super((Plugin) plugin, ListenerPriority.NORMAL, new PacketType[]{PacketType.Play.Server.SPAWN_ENTITY_LIVING});
+        super((Plugin) plugin, ListenerPriority.NORMAL, new PacketType[]{PacketType.Play.Server.SPAWN_ENTITY});
         this.plugin = plugin;
         this.protocolManager.addPacketListener((PacketListener) this);
     }
@@ -46,7 +46,7 @@ public class SimpleProtocolLibHook extends PacketAdapter implements ProtocolLibH
 
     public void onPacketSending(PacketEvent event)
     {
-        if (event.getPacketType() != PacketType.Play.Server.SPAWN_ENTITY_LIVING)
+        if (event.getPacketType() != PacketType.Play.Server.SPAWN_ENTITY)
             return;
         PacketContainer packet = event.getPacket();
         LivingEntity ent = identifyEntity(packet);
@@ -80,6 +80,6 @@ public class SimpleProtocolLibHook extends PacketAdapter implements ProtocolLibH
     {
         StructureModifier<Double> doubles = packet.getDoubles();
         double prev = ((Double) doubles.read(1)).doubleValue();
-        doubles.write(1, Double.valueOf(prev + -2.0D));
+        doubles.write(1, Double.valueOf(prev + CHANGE_Y));
     }
 }


### PR DESCRIPTION
Bump build to Java 21.

Update to 1.19+ supported entity spawn packet listener (all entities now share a packet).

Move to modern passenger management (i.e reference the primary passenger where applicable).